### PR TITLE
Added a default intrinsic content size value.

### DIFF
--- a/MKDropdownMenu/MKDropdownMenu.m
+++ b/MKDropdownMenu/MKDropdownMenu.m
@@ -1445,6 +1445,10 @@ static const CGFloat kScrollViewBottomSpace = 5;
     return self.contentViewController.roundedCorners;
 }
 
+- (CGSize)intrinsicContentSize {
+    return UILayoutFittingExpandedSize;
+}
+
 #pragma mark - Public Methods
 
 - (NSInteger)numberOfComponents {


### PR DESCRIPTION
Fixed an issue when MKDropdownMenu view is not visible on iOS 11 devices.